### PR TITLE
Consumer Key と Consumer Secret を動的に変更できるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.3.0 Release notes (2019-XX-XX)
+1.3.0 Release notes (2019-04-09)
 =============================================================
 
 ### API Breaking Changes
@@ -11,6 +11,8 @@
   * You can call this method to switch to a different key when logging in to Studyplus or posting study records.
   * If multiple applications are connected with Studyplus, you need to call this method.
   * If there is only one connected application, you do not need to call this method.
+* Built with Xcode 10.2 & Swift 5.
+* Update library.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+1.3.0 Release notes (2018-08-21)
+=============================================================
+
+### API Breaking Changes
+
+* None.
+
+### Enhancements
+
+* change the consumer key and secret.
+  * You can call this method to switch to a different key when logging in to Studyplus or posting study records.
+  * If multiple applications are connected with Studyplus, you need to call this method.
+  * If there is only one connected application, you do not need to call this method.
+
+### Bugfixes
+
+* None.
+
 1.2.0 Release notes (2018-07-02)
 =============================================================
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "kishikawakatsumi/KeychainAccess" == 3.1.2
+github "kishikawakatsumi/KeychainAccess" == 3.2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "kishikawakatsumi/KeychainAccess" "v3.1.2"
+github "kishikawakatsumi/KeychainAccess" "v3.2.0"

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.3.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,5 @@ platform :ios, '8.0'
 use_frameworks!
 
 target :Demo do
-    pod 'KeychainAccess', '3.1.2'
+    pod 'KeychainAccess', '3.2.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - KeychainAccess (3.1.2)
+  - KeychainAccess (3.2.0)
 
 DEPENDENCIES:
-  - KeychainAccess (= 3.1.2)
+  - KeychainAccess (= 3.2.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - KeychainAccess
 
 SPEC CHECKSUMS:
-  KeychainAccess: b3816fddcf28aa29d94b10ec305cd52be14c472b
+  KeychainAccess: 3b1bf8a77eb4c6ea1ce9404c292e48f948954c6b
 
-PODFILE CHECKSUM: a676396cbae51e5a6bac480d6b8d92b81dcc7ce4
+PODFILE CHECKSUM: 352692b69057b39cb68c163e0c65e32a69dd4b91
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/StudyplusSDK-V2.podspec
+++ b/StudyplusSDK-V2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = "StudyplusSDK-V2"
-  s.version               = "1.2.0"
+  s.version               = "1.3.0"
   s.summary               = "StudyplusSDK-V2 is Studyplus iOS SDK for Swift"
   s.homepage              = "http://info.studyplus.jp"
   s.license               = { :type => "MIT", :file => "LICENSE" }
@@ -13,4 +13,3 @@ Pod::Spec.new do |s|
   s.author                = { "studyplus" => "sutou@studyplus.jp" }
   s.dependency 'KeychainAccess', '3.1.1'
 end
-

--- a/StudyplusSDK-V2.podspec
+++ b/StudyplusSDK-V2.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.ios.frameworks        = ['UIKit', 'Foundation']
   s.author                = { "studyplus" => "sutou@studyplus.jp" }
-  s.dependency 'KeychainAccess', '3.1.2'
+  s.dependency 'KeychainAccess', '3.2.0'
 end

--- a/StudyplusSDK.xcodeproj/project.pbxproj
+++ b/StudyplusSDK.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = studyplus;
 				TargetAttributes = {
 					183FDA661E7510920085589F = {
@@ -345,7 +345,7 @@
 			};
 			buildConfigurationList = 183FDA611E7510920085589F /* Build configuration list for PBXProject "StudyplusSDK" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,

--- a/StudyplusSDK.xcodeproj/project.pbxproj
+++ b/StudyplusSDK.xcodeproj/project.pbxproj
@@ -322,22 +322,22 @@
 				TargetAttributes = {
 					183FDA661E7510920085589F = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					183FDA6F1E7510920085589F = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					183FDA841E7510F00085589F = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					183FDA971E7510F10085589F = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 183FDA841E7510F00085589F;
 					};
@@ -405,7 +405,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/KeychainAccess/KeychainAccess.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -414,7 +414,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B53884D9564CE4E4A42A331F /* [CP] Check Pods Manifest.lock */ = {
@@ -519,6 +519,7 @@
 		183FDA791E7510920085589F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -582,6 +583,7 @@
 		183FDA7A1E7510920085589F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -638,6 +640,7 @@
 		183FDA7C1E7510920085589F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -658,13 +661,14 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		183FDA7D1E7510920085589F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -683,7 +687,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.studyplus.StudyplusSDK;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -695,7 +699,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.studyplus.StudyplusSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -707,7 +711,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.studyplus.StudyplusSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -715,7 +719,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 89218006880625385A599621 /* Pods-Demo.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Demo/Info.plist;
@@ -724,7 +728,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.studyplus.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -732,7 +736,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 617BD1B3D302AA6EB05AD450 /* Pods-Demo.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Demo/Info.plist;
@@ -741,21 +745,21 @@
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.studyplus.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
 		183FDAA31E7510F10085589F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = DemoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.studyplus.DemoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
 			};
 			name = Debug;
@@ -763,14 +767,14 @@
 		183FDAA41E7510F10085589F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = DemoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.studyplus.DemoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
 			};
 			name = Release;

--- a/StudyplusSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/StudyplusSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/StudyplusSDK.xcodeproj/xcshareddata/xcschemes/StudyplusSDK.xcscheme
+++ b/StudyplusSDK.xcodeproj/xcshareddata/xcschemes/StudyplusSDK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/StudyplusSDK/Info.plist
+++ b/StudyplusSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -151,11 +151,6 @@ final public class Studyplus {
     ///   - success: callback when success to post the studyRecord
     ///   - failure: callback when failure to post the studyRecord
     public func post(studyRecord: StudyplusRecord, success: @escaping () -> Void, failure: @escaping (_ error: StudyplusError) -> Void) {
-
-        if self.debug {
-            success()
-            return
-        }
         
         if !self.isConnected() {
             failure(.notConnected)
@@ -164,6 +159,11 @@ final public class Studyplus {
         
         guard let accessToken = self.accessToken() else {
             failure(.notConnected)
+            return
+        }
+        
+        if self.debug {
+            success()
             return
         }
         

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -162,7 +162,11 @@ final public class Studyplus {
             return
         }
         
-        guard let accessToken = self.accessToken() else { return }
+        guard let accessToken = self.accessToken() else {
+            failure(.notConnected)
+            return
+        }
+        
         let request: StudyplusAPIRequest = StudyplusAPIRequest(accessToken: accessToken)
         request.post(path: "study_records", params: studyRecord.requestParams(), success: { (response) in
             success()

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -230,14 +230,16 @@ final public class Studyplus {
     }
     
     /// Change the consumer key and secret.
-    /// You can call this method to switch to a different key when logging in to Studyplus or posting study records.
+    /// Calling this method allows you to switch to another consumer key and secret. For example, you log in to Studyplus, log out, and post a study record.
     /// If multiple applications are connected with Studyplus, you need to call this method.
     /// If there is only one connected application, you do not need to call this method.
+    /// If multiple applications are connected with Studyplus, do not forget to set up custom URL schemes.
     ///
     /// StudyplusAPI用のConsumer Key と Secret を変更します。
-    /// このメソッドを呼ぶと、Studyplusにログインしたり、勉強記録を投稿するときに別の Consumer Key と Secret に切り替えることができます。
-    /// 複数のアプリケーションがStudyplusと連携されている場合は、このメソッドを呼ぶ必要があります。
+    /// このメソッドを呼ぶとStudyplusにログイン、ログアウト、勉強記録を投稿するときなどに、別の Consumer Key と Secret に切り替えることができます。
+    /// 複数のアプリケーションがStudyplusと連携している場合は、このメソッドを呼ぶ必要があります。
     /// 連携されたアプリケーションが1つしかない場合は、このメソッドを呼ぶ必要はありません。
+    /// 複数のアプリケーションがStudyplusと連携している場合は、カスタムURLスキーマの設定を忘れないように注意してください。
     ///
     /// - Parameter
     ///   - consumerKey: consumer key

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -55,14 +55,14 @@ final public class Studyplus {
 
      StudyplusAPI用のConsumer Keyです。
      */
-    public let consumerKey: String
+    public private(set) var consumerKey: String
     
     /**
      Consumer Secret for Studyplus API.
 
      StudyplusAPI用のConsumer Secretです。
      */
-    public let consumerSecret: String
+    public private(set) var consumerSecret: String
     
     /**
      see StudyplusLoginDelegate protocol
@@ -223,6 +223,25 @@ final public class Studyplus {
         }
         
         return true
+    }
+    
+    /// Change the consumer key and secret.
+    /// You can call this method to switch to a different key when logging in to Studyplus or posting study records.
+    /// If multiple applications are connected with Studyplus, you need to call this method.
+    /// If there is only one connected application, you do not need to call this method.
+    ///
+    /// StudyplusAPI用のConsumer Key と Secret を変更します。
+    /// このメソッドを呼ぶと、Studyplusにログインしたり、勉強記録を投稿するときに別の Consumer Key と Secret に切り替えることができます。
+    /// 複数のアプリケーションがStudyplusと連携されている場合は、このメソッドを呼ぶ必要があります。
+    /// 連携されたアプリケーションが1つしかない場合は、このメソッドを呼ぶ必要はありません。
+    ///
+    /// - Parameter
+    ///   - consumerKey: consumer key
+    ///   - consumerSecret: consumer secret
+    public func change(consumerKey: String, consumerSecret: String) {
+        
+        self.consumerKey = consumerKey
+        self.consumerSecret = consumerSecret
     }
     
     // MARK: - private method

--- a/StudyplusSDK/StudyplusLoginDelegate.swift
+++ b/StudyplusSDK/StudyplusLoginDelegate.swift
@@ -55,6 +55,6 @@ public protocol StudyplusLoginDelegate: class {
 
 public extension StudyplusLoginDelegate {
     
-    public func studyplusDidCancelToLogin() {
+    func studyplusDidCancelToLogin() {
     }
 }


### PR DESCRIPTION
## 背景

- 現在のSDKは Key と Secret がアプリ起動後に変更されることを想定していない
  -  これまでSDKと連携するアプリが1対1のため変更する必要がなかった
- SDKを導入しているアプリで、ひとつのアプリが複数の連携アプリを持ち動的に切り替えたいニーズが出た

## 対応

- プログラムで動的に Consumer Key と Consumer Secret を変更できるように対応
- `change(consumerKey: String, consumerSecret: String)` で変更可能にした
- iOSのSDKは、[Consumer Key ごとに連携アプリのアクセストークンをキーチェーンに保存している](https://github.com/studyplus/Studyplus-iOS-SDK-V2/blob/master/StudyplusSDK/Studyplus.swift#L258-L262)ので、consumerKey と consumerSecret を変更すれば、連携アプリごとにアクセストークンをキーチェーンに保存できる。
- 複数の連携アプリの情報をもつアプリは、連携するとき勉強記録を投稿するとき（ニーズに合わせて）など、 `change` メソッドで Key と Secret を変更して連携先を切り替える必要がある

  - 21370be
  - ff06584

## 既存アプリへの影響
- なし