### PR TITLE
[WIP] StudyplusRecordのdurationプロパティへ24時間上限を追加

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UIViewController, StudyplusLoginDelegate {
         self.resultLabel.text = ""
         
         let recordAmount: StudyplusRecordAmount = StudyplusRecordAmount(amount: 10)
-        let record: StudyplusRecord = StudyplusRecord(duration: duration, recordedAt: Date(), amount: recordAmount, comment: "Today, I studied like anything.")
+        let record: StudyplusRecord = StudyplusRecord(duration: Int(duration), recordedAt: Date(), amount: recordAmount, comment: "Today, I studied like anything.")
 
         Studyplus.shared.post(studyRecord: record, success: { 
             

--- a/StudyplusSDK/StudyplusRecord.swift
+++ b/StudyplusSDK/StudyplusRecord.swift
@@ -74,7 +74,7 @@ public struct StudyplusRecord {
      The seconds of the learning.
      勉強した時間（秒数）です。
      */
-    public let duration: Double
+    public let duration: Int
     
     /**
      The date and time of learning.
@@ -105,7 +105,25 @@ public struct StudyplusRecord {
     ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
     ///   - amount: The amount of learning. 学習量。
     ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。
+    @available(*, deprecated, message: "Use Int type duration initializer instead")
     public init(duration: Double, recordedAt: Date = Date(), amount: StudyplusRecordAmount? = nil, comment: String? = nil) {
+        
+        self.duration = Int(duration)
+        self.recordedAt = recordedAt
+        self.amount = amount
+        self.comment = comment
+    }
+    
+    /// Initialize StudyplusRecord object.
+    ///
+    /// 勉強記録オブジェクトを作成します。
+    ///
+    /// - Parameters:
+    ///   - duration: Specify the seconds of the learning. 勉強した時間（秒数）を指定してください。
+    ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
+    ///   - amount: The amount of learning. 学習量。
+    ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。
+    public init(duration: Int, recordedAt: Date = Date(), amount: StudyplusRecordAmount? = nil, comment: String? = nil) {
         
         self.duration = duration
         self.recordedAt = recordedAt


### PR DESCRIPTION
## 背景

- 指定した日付の中で勉強した時間の投稿を受け付けるというのが基本的な仕様
  - SDKでは24時間より多く指定が可能で、上記の意図と異なる使い方ができてしまう

##  対応
- StudyplusRecordのdurationプロパティにて、24時間(86400)より上の値を指定して投稿を実行した際にエラーを返却

- 上記の値が上限の場合、StudyplusRecordのdurationプロパティがDouble型である必要がないためInt型へ変更

## 既存アプリへの影響
- StudyplusRecordのdurationプロパティがDouble型想定の`StudyplusRecord(duration:recordedAt:amount:comment:)` をdeprecated指定
  - 既存と同様に動作はするよう実装
