### PR TITLE
StudyplusRecordのdurationプロパティへ24時間上限を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+1.3.1 Release notes (2019-06-17)
+=============================================================
+
+### API Breaking Changes
+
+* None.
+
+### Enhancements
+
+* added lower than 24 hours validation when post study record.
+
+### Bugfixes
+
+* None.
+
 1.3.0 Release notes (2019-04-09)
 =============================================================
 

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UIViewController, StudyplusLoginDelegate {
         self.resultLabel.text = ""
         
         let recordAmount: StudyplusRecordAmount = StudyplusRecordAmount(amount: 10)
-        let record: StudyplusRecord = StudyplusRecord(duration: Int(duration), recordedAt: Date(), amount: recordAmount, comment: "Today, I studied like anything.")
+        let record: StudyplusRecord = StudyplusRecord(duration: duration, recordedAt: Date(), amount: recordAmount, comment: "Today, I studied like anything.")
 
         Studyplus.shared.post(studyRecord: record, success: { 
             

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UIViewController, StudyplusLoginDelegate {
         self.resultLabel.text = ""
         
         let recordAmount: StudyplusRecordAmount = StudyplusRecordAmount(amount: 10)
-        let record: StudyplusRecord = StudyplusRecord(duration: duration, recordedAt: Date(), amount: recordAmount, comment: "Today, I studied like anything.")
+        let record: StudyplusRecord = StudyplusRecord(duration: Int(duration), recordedAt: Date(), amount: recordAmount, comment: "Today, I studied like anything.")
 
         Studyplus.shared.post(studyRecord: record, success: { 
             

--- a/StudyplusSDK-V2.podspec
+++ b/StudyplusSDK-V2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = "StudyplusSDK-V2"
-  s.version               = "1.3.0"
+  s.version               = "1.3.1"
   s.summary               = "StudyplusSDK-V2 is Studyplus iOS SDK for Swift"
   s.homepage              = "http://info.studyplus.jp"
   s.license               = { :type => "MIT", :file => "LICENSE" }

--- a/StudyplusSDK/Info.plist
+++ b/StudyplusSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -152,7 +152,7 @@ final public class Studyplus {
     ///   - failure: callback when failure to post the studyRecord
     public func post(studyRecord: StudyplusRecord, success: @escaping () -> Void, failure: @escaping (_ error: StudyplusError) -> Void) {
         
-        guard StudyplusRecord.durationRange ~= Int(floor(studyRecord.duration)) else {
+        guard StudyplusRecord.durationRange ~= Int(studyRecord.duration) else {
             failure(.postRecordFailed)
             return
         }

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -152,7 +152,7 @@ final public class Studyplus {
     ///   - failure: callback when failure to post the studyRecord
     public func post(studyRecord: StudyplusRecord, success: @escaping () -> Void, failure: @escaping (_ error: StudyplusError) -> Void) {
         
-        guard StudyplusRecord.durationRange ~= Int(studyRecord.duration) else {
+        guard StudyplusRecord.durationRange ~= Int(floor(studyRecord.duration)) else {
             failure(.postRecordFailed)
             return
         }

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -152,6 +152,11 @@ final public class Studyplus {
     ///   - failure: callback when failure to post the studyRecord
     public func post(studyRecord: StudyplusRecord, success: @escaping () -> Void, failure: @escaping (_ error: StudyplusError) -> Void) {
         
+        guard StudyplusRecord.durationRange ~= studyRecord.duration else {
+            failure(.postRecordFailed)
+            return
+        }
+        
         if !self.isConnected() {
             failure(.notConnected)
             return

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -152,7 +152,7 @@ final public class Studyplus {
     ///   - failure: callback when failure to post the studyRecord
     public func post(studyRecord: StudyplusRecord, success: @escaping () -> Void, failure: @escaping (_ error: StudyplusError) -> Void) {
         
-        guard StudyplusRecord.durationRange ~= studyRecord.duration else {
+        guard StudyplusRecord.durationRange ~= Int(studyRecord.duration) else {
             failure(.postRecordFailed)
             return
         }

--- a/StudyplusSDK/StudyplusRecord.swift
+++ b/StudyplusSDK/StudyplusRecord.swift
@@ -69,6 +69,8 @@ private extension Date {
  Studyplusに投稿する一件の勉強記録を表現するクラスです。
  */
 public struct StudyplusRecord {
+    
+    static let durationRange = 0...(24 * 60 * 60)
 
     /**
      The seconds of the learning.
@@ -102,6 +104,8 @@ public struct StudyplusRecord {
     ///
     /// - Parameters:
     ///   - duration: Specify the seconds of the learning. 勉強した時間（秒数）を指定してください。
+    ///     - min: 0
+    ///     - max: 86400 (24h)
     ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
     ///   - amount: The amount of learning. 学習量。
     ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。
@@ -120,6 +124,8 @@ public struct StudyplusRecord {
     ///
     /// - Parameters:
     ///   - duration: Specify the seconds of the learning. 勉強した時間（秒数）を指定してください。
+    ///     - min: 0
+    ///     - max: 86400 (24h)
     ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
     ///   - amount: The amount of learning. 学習量。
     ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。

--- a/StudyplusSDK/StudyplusRecord.swift
+++ b/StudyplusSDK/StudyplusRecord.swift
@@ -74,7 +74,7 @@ public struct StudyplusRecord {
      The seconds of the learning.
      勉強した時間（秒数）です。
      */
-    public let duration: Double
+    public let duration: Int
     
     /**
      The date and time of learning.
@@ -105,7 +105,25 @@ public struct StudyplusRecord {
     ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
     ///   - amount: The amount of learning. 学習量。
     ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。
+    @available(*, deprecated, message: "Use Int type duration initializer instead")
     public init(duration: Double, recordedAt: Date = Date(), amount: StudyplusRecordAmount? = nil, comment: String? = nil) {
+        
+        self.duration = Int(duration)
+        self.recordedAt = recordedAt
+        self.amount = amount
+        self.comment = comment
+    }
+    
+    /// Initialize StudyplusRecord object.
+    ///
+    /// 勉強記録オブジェクトを作成します。
+    ///
+    /// - Parameters:
+    ///   - duration: Specify the seconds of the learning. 勉強した時間（秒数）を指定してください。
+    ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
+    ///   - amount: The amount of learning. 学習量。
+    ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。
+    public init(duration: Int, recordedAt: Date = Date(), amount: StudyplusRecordAmount? = nil, comment: String? = nil) {
         
         self.duration = duration
         self.recordedAt = recordedAt

--- a/StudyplusSDK/StudyplusRecord.swift
+++ b/StudyplusSDK/StudyplusRecord.swift
@@ -76,7 +76,7 @@ public struct StudyplusRecord {
      The seconds of the learning.
      勉強した時間（秒数）です。
      */
-    public let duration: Int
+    public let duration: Double
     
     /**
      The date and time of learning.
@@ -109,27 +109,7 @@ public struct StudyplusRecord {
     ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
     ///   - amount: The amount of learning. 学習量。
     ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。
-    @available(*, deprecated, message: "Use Int type duration initializer instead")
     public init(duration: Double, recordedAt: Date = Date(), amount: StudyplusRecordAmount? = nil, comment: String? = nil) {
-        
-        self.duration = Int(duration)
-        self.recordedAt = recordedAt
-        self.amount = amount
-        self.comment = comment
-    }
-    
-    /// Initialize StudyplusRecord object.
-    ///
-    /// 勉強記録オブジェクトを作成します。
-    ///
-    /// - Parameters:
-    ///   - duration: Specify the seconds of the learning. 勉強した時間（秒数）を指定してください。
-    ///     - min: 0
-    ///     - max: 86400 (24h)
-    ///   - recordedAt: Time the learning is ended. 学習を終えた日時。
-    ///   - amount: The amount of learning. 学習量。
-    ///   - comment: Studyplus timeline comment. Studyplusのタイムライン上で表示されるコメント。
-    public init(duration: Int, recordedAt: Date = Date(), amount: StudyplusRecordAmount? = nil, comment: String? = nil) {
         
         self.duration = duration
         self.recordedAt = recordedAt


### PR DESCRIPTION
## 背景

- 指定した日付の中で勉強した時間の投稿を受け付けるというのが基本的な仕様
  - SDKでは24時間より多く指定が可能で、上記の意図と異なる使い方ができてしまう

##  対応
- StudyplusRecordのdurationプロパティにて、24時間(86400)より上の値を指定して投稿を実行した際にエラーを返却
  - 併せて、下限(0)も明確に定義

- 上記の値が上限の場合、StudyplusRecordのdurationプロパティがDouble型である必要がないためInt型へ変更

## 既存アプリへの影響
- StudyplusRecordのdurationプロパティがDouble型想定の`StudyplusRecord(duration:recordedAt:amount:comment:)` をdeprecated指定
  - 既存と同様に動作はするよう実装
