### PR TITLE
StudyplusのAppStoreのURLを変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+1.3.2 Release notes (2019-06-21)
+=============================================================
+
+### API Breaking Changes
+
+* None.
+
+### Enhancements
+
+* change url of app store
+
+### Bugfixes
+
+* None.
+
 1.3.1 Release notes (2019-06-17)
 =============================================================
 

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/StudyplusSDK-V2.podspec
+++ b/StudyplusSDK-V2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = "StudyplusSDK-V2"
-  s.version               = "1.3.1"
+  s.version               = "1.3.2"
   s.summary               = "StudyplusSDK-V2 is Studyplus iOS SDK for Swift"
   s.homepage              = "http://info.studyplus.jp"
   s.license               = { :type => "MIT", :file => "LICENSE" }

--- a/StudyplusSDK/Info.plist
+++ b/StudyplusSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -303,7 +303,7 @@ final public class Studyplus {
             
             if self.openAppStoreIfNotInstalled {
             
-                let appStoreURLString: String = "https://itunes.apple.com/jp/app/mian-qiangga-leshiku-xuku!/id505410049?mt=8"
+                let appStoreURLString: String = "https://apps.apple.com/jp/app/id505410049?mt=8"
                 guard let appStoreURL = URL(string: appStoreURLString) else { return }
                 applicationOpen(appStoreURL)
             }

--- a/StudyplusSDK/Studyplus.swift
+++ b/StudyplusSDK/Studyplus.swift
@@ -263,8 +263,8 @@ final public class Studyplus {
               let consumerKey = data["consumerKey"],
               let consumerSecret = data["consumerSecret"] else {
 
-            assert(false, "StudyplusSDK: *** Pleease set consumerKey and consumerSecret in your Info.plist. ***")
-            print("StudyplusSDK: *** Pleease set consumerKey and consumerSecret in your Info.plist. ***")
+            assert(false, "StudyplusSDK: *** Please set consumerKey and consumerSecret in your Info.plist. ***")
+            print("StudyplusSDK: *** Please set consumerKey and consumerSecret in your Info.plist. ***")
 
             self.consumerKey = ""
             self.consumerSecret = ""
@@ -273,8 +273,8 @@ final public class Studyplus {
         
         if consumerKey == "set_your_consumerKey" || consumerSecret == "set_your_consumerSecret" {
             
-            assert(false, "StudyplusSDK: *** Pleease set consumerKey and consumerSecret in Info.plist. ***")
-            print("StudyplusSDK: *** Pleease set consumerKey and consumerSecret in your Info.plist. ***")
+            assert(false, "StudyplusSDK: *** Please set consumerKey and consumerSecret in Info.plist. ***")
+            print("StudyplusSDK: *** Please set consumerKey and consumerSecret in your Info.plist. ***")
 
             self.consumerKey = ""
             self.consumerSecret = ""


### PR DESCRIPTION
## 背景

- App StoreのURLが以下のように変更になったため
  - 変更前 https://itunes.apple.com/jp/app/id505410049?mt=8
  - 変更後 https://apps.apple.com/jp/app/id505410049?mt=8

##  対応
- StudyplusのURLを変更
- ついでにtypoを修正

## 既存アプリへの影響
特になし